### PR TITLE
Minor improvement to copas.step()

### DIFF
--- a/doc/us/reference.html
+++ b/doc/us/reference.html
@@ -96,6 +96,9 @@ are used to register servers and to execute the main loop of Copas:</p>
         handlers. When a server accepts a connection, Copas calls the
         associated handler passing the client socket returned by
         <code>socket.accept()</code>. The <code>timeout</code> parameter is optional.
+				It returns <code>false</code> when no data was handled (timeout) or 
+				<code>true</code> if there was data handled (or alternatively nil + error
+				message in case of errors).
     </dd>
 </dl>
 

--- a/src/copas/copas.lua
+++ b/src/copas/copas.lua
@@ -437,10 +437,12 @@ end
 -------------------------------------------------------------------------------
 -- Dispatcher loop step.
 -- Listen to client requests and handles them
+-- Returns false if no data was handled (timeout), or true if there was data
+-- handled (or nil + error message)
 -------------------------------------------------------------------------------
 function step(timeout)
   local err = _select (timeout)
-  if err == "timeout" then return end
+  if err == "timeout" then return false end
 
   if err then
     error(err)
@@ -451,6 +453,7 @@ function step(timeout)
       tsk:tick (ev)
     end
   end
+  return true
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Very minor update to step() function, to return a result based upon data handled or timeout. Fully transparent, no breaking of existing code.
This tells the caller that it should asap resume IO (eg. next call to step()) because data is coming in, or alternatively it timed out and there is (some) time to do something else temporarily.
