### PR TITLE
pin LuaSocket version to 3.0rc1-2

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -9,5 +9,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - uses: leafo/gh-actions-lua@v9
+      - uses: leafo/gh-actions-luarocks@v4
+      - name: Lint rockspecs
+        run: |
+          for i in $(find . -type f -name "*.rockspec"); do echo $i; luarocks lint $i || exit 1; done
       - name: Luacheck
         uses: lunarmodules/luacheck@v0

--- a/rockspec/copas-3.0.0-3.rockspec
+++ b/rockspec/copas-3.0.0-3.rockspec
@@ -1,6 +1,6 @@
 local package_name = "copas"
-local package_version = "cvs"
-local rockspec_revision = "6"
+local package_version = "3.0.0"
+local rockspec_revision = "3"
 local github_account_name = "lunarmodules"
 local github_repo_name = package_name
 


### PR DESCRIPTION
The newly release 3.0 version of LuaSocket apparently breaks the Copas test suite. For now pinning it to the old RC.