### PR TITLE
fix(autoclose) only auto-close accepted connections

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -103,8 +103,14 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
     <dt><strong>Copas x.x.x</strong> [unreleased]</dt>
 	<dd><ul>
         <li>Fixed: yielding to the Copas scheduler from user-code now throws a proper error and
-        no longer breaks the loop. Breaking the loop could also happen if a thread terminated with
-        at leaast 2 return values.</li>
+        no longer breaks the loop. Breaking the loop could also happen if a thread returned with
+        at least 2 return values.</li>
+        <li>Fixed: wrongly auto-closing sockets. Upon exiting a coroutine, sockets would be automatically
+        closed. This should only be the case for accepted TCP connections on a TCP server socket. This caused issues
+        for sockets shared between threads.<br />
+        [breaking]: this changes behavior, auto-close is now determined when accepting the connection, and no longer when
+        terminating the handler thread. This will only affect users that dynamically change <code>copas.autoclose</code>
+        at runtime.</li>
         <li>Added: added <code>sempahore:destroy()</code></li>
         <li>Added: <code>copas.settimeouts</code>, to set separate timeouts for connect, send, receive</li>
         <li>Added: queue class, see module "copas.queue"</li>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -157,7 +157,8 @@ are used to register servers and to execute the main loop of Copas:</p>
     </dd>
 
     <dt><strong><code>copas.autoclose</code></strong></dt>
-    <dd>Constant that controls whether sockets are automatically closed.<br />
+    <dd>Boolean that controls whether sockets are automatically closed (defaults to <code>true</code>).
+        This only applies to incoming connections accepted on a TCP server socket.<br />
         When a TCP handler function completes and terminates, then the client
         socket will be automatically closed when <code>copas.autoclose</code> is
         truthy.


### PR DESCRIPTION
Only if a connection originates from accepting a connection request
on a server socket it will be auto-closed.

fixes #122 