### PR TITLE
fix(queue) sleeping workers were not destroyed/released

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -112,6 +112,7 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
         is now exported as <code>http.getcreatefunc()</code>. This allows to capture the socket used by the
         request. When using streaming responses, for example with server-side-events, this can be used to modify
         the timeouts, or for closing the stream.</li>
+        <li>Fix: empty queues were not destroyed properly and could prevent Copas from exiting</li>
 	</ul></dd>
 
     <dt><strong>Copas 4.0.0</strong> [29/Jul/2022]</dt>

--- a/src/copas/queue.lua
+++ b/src/copas/queue.lua
@@ -85,6 +85,11 @@ function Queue:stop()
     self.stopping = true
     self.lock = Lock.new()
     self.lock:get() -- close the lock
+    if self:get_size() == 0 then
+      -- queue is already empty, so "pop" function cannot call destroy on next
+      -- pop, so destroy now.
+      self:destroy()
+    end
   end
   return true
 end
@@ -125,6 +130,7 @@ do
     if self.lock then
       self.lock:destroy()
     end
+    self.sema:destroy()
     setmetatable(self, destroyed_queue_mt)
     return true
   end

--- a/tests/queue.lua
+++ b/tests/queue.lua
@@ -75,5 +75,19 @@ copas.loop(function()
   test_complete = true
 end)
 
+-- copas loop exited when here
+
 assert(test_complete, "test did not complete!")
-print("test success!")
+print("test 1 success!")
+
+
+
+-- destroying a queue while workers are idle
+copas.loop(function()
+  local q = Queue:new()
+  q:add_worker(function() end)
+  copas.sleep(0.5) -- to activate the worker, which will now be blocked on the q semaphore
+  q:stop()  -- this should exit the idle workers and exit the copas loop
+end)
+
+print("test 2 success!")


### PR DESCRIPTION
This would prevent Copas from exiting when all work was done.