### PR TITLE
fix(gc) when idle do occasional GC

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -100,6 +100,13 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
+    <dt><strong>Copas 4.2.x</strong> [unreleased]</dt>
+	<dd><ul>
+        <li>Fix: when the loop is idle, do an occasional GC to clean out any lingering
+            non-closed sockets. This could prevent the loop from exiting.</li>
+        <li>Fix: in debug mode very large data is now truncated when displayed.</li>
+	</ul></dd>
+
     <dt><strong>Copas 4.2.0</strong> [06/Sep/2022]</dt>
 	<dd><ul>
         <li>Change: pick up datagram size from newer LuaSocket versions.</li>

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -1426,6 +1426,12 @@ function copas.step(timeout)
 
   if err then
     if err == "timeout" then
+      if timeout + 0.01 > TIMEOUT_PRECISION and math.random(100) > 90 then
+        -- we were idle, so occasionally do a GC sweep to ensure lingering
+        -- sockets are closed, and we don't accidentally block the loop from
+        -- exiting
+        collectgarbage()
+      end
       return false
     end
     return nil, err


### PR DESCRIPTION
when the loop is idle, do an occasional GC to clean out any lingering non-closed sockets. This could prevent the loop from exiting.