### PR TITLE
fix(timer) if callback errors, do not fail the timer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -100,11 +100,19 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
+    <dt><strong>Copas 4.4.0</strong> [unreleased]</dt>
+	<dd><ul>
+        <li>Fix: an error in the timer callback would kill the timer.</li>
+        <li>Added: <code>copas.geterrorhandler</code> to retrieve the active errorhandler.</li>
+        <li>Added: option <code>errorhandler</code> for timer objects.</li>
+        <li>Change: renamed <code>copas.setErrorHandler</code> to <code>copas.seterrorhandler</code>.</li>
+        <li>Change: renamed <code>copas.useSocketTimeoutErrors</code> to <code>copas.usesockettimeouterrors</code>.</li>
+    </ul></dd>
+
     <dt><strong>Copas 4.3.2</strong> [03/Oct/2022]</dt>
 	<dd><ul>
         <li>Fix: error handler for timeouts. Underlying <a href="https://github.com/keplerproject/coxpcall/issues/18">
-        bug is in coxpcall</a>, and hence this only applies to PuC Lua 5.1.
-        </li>
+        bug is in coxpcall</a>, and hence this only applies to PuC Lua 5.1.</li>
     </ul></dd>
 
     <dt><strong>Copas 4.3.1</strong> [21/Sep/2022]</dt>
@@ -122,7 +130,7 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
         <li>Fix: in debug mode very large data is now truncated when displayed.</li>
         <li>Fix: the receive methods could starve other threads on high-throughput.</li>
         <li>Change: order of <code>copas.addnamedthread</code> args.</li>
-        <li>Fix: <code>copas.recievepartial</code> could return early with no data received
+        <li>Fix: <code>copas.receivepartial</code> could return early with no data received
         if the `prefix` parameter was specified.</li>
         <li>Change: renamed <code>copas.receivePartial</code> to <code>copas.receivepartial</code>.</li>
         <li>Added: <code>sock:receivepartial</code> to better process streaming TCP data.</li>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -177,6 +177,12 @@ are used to register servers and to execute the main loop of Copas:</p>
         See also <code>copas.running</code>.
     </dd>
 
+    <dt><strong><code>func = copas.geterrorhandler([coro])</code></strong></dt>
+    <dd>Returns the currently active errorhandler function for the coroutine (either
+        the explicitly set errorhandler, or the default one).
+        <code>coro</code> will default to the currently running coroutine if omitted.
+    </dd>
+
     <dt><strong><code>copas.getsocketname(skt)</code></strong></dt>
         <dd>Returns the name for the socket.
     </dd>
@@ -188,7 +194,7 @@ are used to register servers and to execute the main loop of Copas:</p>
 
     <dt><strong><code>copas.gettraceback([msg], [co], [skt])</code></strong></dt>
         <dd>Creates a traceback (string). Can be used from custom errorhandlers to create
-        a proper trace. See <code>copas.setErrorHandler</code>.
+        a proper trace. See <code>copas.seterrorhandler</code>.
     </dd>
 
     <dt><strong><code>func = copas.handler(connhandler [, sslparams])</code></strong></dt>
@@ -232,7 +238,7 @@ are used to register servers and to execute the main loop of Copas:</p>
         <code>copas.finished()</code>.
     </dd>
 
-    <dt><strong><code>copas.setErrorHandler([func], [default])</code></strong></dt>
+    <dt><strong><code>copas.seterrorhandler([func], [default])</code></strong></dt>
     <dd>Sets the error handling function for the current thread.
         Any errors will be forwarded to this handler, it will receive the
         error, coroutine, and socket as arguments;
@@ -551,6 +557,8 @@ exchange data with other services.</p>
         <li><code>options.callback</code>: is the function to execute on timer expiry.
             The callback function has <code>function(timer_obj, params)</code> as signature, where
             <code>params</code> is the value initially passed in <code>options.params</code></li>
+        <li><code>options.errorhandler</code> (optional): a Copas errorhandler function (see
+        <code>copas.seterrorhandler</code> for the signature.</li>
     </ul>
     </dd>
 
@@ -701,7 +709,7 @@ servers.
     <code>copas.settimeouts</code>, where <code>nil</code> means 'do not change' the timeout.<br/>
     If a timeout is hit, the operation will return <code>nil + "timeout"</code>.
     Timeouts are applied on: <code>receive, receivefrom, receivepartial, send, connect, dohandshake</code>.<br />
-    See <code>copas.useSocketTimeoutErrors()</code> below for alternative error messages.
+    See <code>copas.usesockettimeouterrors()</code> below for alternative error messages.
     </dd>
 
     <dt><strong><code>copas.settimeouts(skt, [connect], [send], [receive])</code></strong></dt>
@@ -711,7 +719,7 @@ servers.
     <code>copas.settimeout</code>, where <code>nil</code> means 'wait indefinitely'.<br/>
     If a timeout is hit, the operation will return <code>nil + "timeout"</code>.
     Timeouts are applied on: <code>receive, receivefrom, receivepartial, send, connect, dohandshake</code>.<br />
-    See <code>copas.useSocketTimeoutErrors()</code> below for alternative error messages.
+    See <code>copas.usesockettimeouterrors()</code> below for alternative error messages.
     </dd>
 
     <dt><strong><code>bool = copas.step([timeout])</code></strong></dt>
@@ -744,7 +752,7 @@ servers.
     implementations.
     </dd>
 
-    <dt><strong><code>copas.useSocketTimeoutErrors([bool])</code></strong></dt>
+    <dt><strong><code>copas.usesockettimeouterrors([bool])</code></strong></dt>
     <dd>Sets the timeout errors to return for the current co-routine.
     The default is <code>false</code>, meaning
     that a timeout error will always return an error string <code>"timeout"</code>.

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -996,6 +996,7 @@ end
 
 local _errhandlers = setmetatable({}, { __mode = "k" })   -- error handler per coroutine
 
+
 function copas.gettraceback(msg, co, skt)
   local co_str = co == nil and "nil" or copas.getthreadname(co)
   local skt_str = skt == nil and "nil" or copas.getsocketname(skt)
@@ -1015,11 +1016,13 @@ function copas.gettraceback(msg, co, skt)
   return debug.traceback(msg_str, 2)
 end
 
+
 local function _deferror(msg, co, skt)
   print(copas.gettraceback(msg, co, skt))
 end
 
-function copas.setErrorHandler (err, default)
+
+function copas.seterrorhandler(err, default)
   assert(err == nil or type(err) == "function", "Expected the handler to be a function, or nil")
   if default then
     assert(err ~= nil, "Expected the handler to be a function when setting the default")
@@ -1028,6 +1031,14 @@ function copas.setErrorHandler (err, default)
     _errhandlers[coroutine_running()] = err
   end
 end
+copas.setErrorHandler = copas.seterrorhandler  -- deprecated; old casing
+
+
+function copas.geterrorhandler(co)
+  co = co or coroutine_running()
+  return _errhandlers[co] or _deferror
+end
+
 
 -- if `bool` is truthy, then the original socket errors will be returned in case of timeouts;
 -- `timeout, wantread, wantwrite, Operation already in progress`. If falsy, it will always

--- a/src/copas/timer.lua
+++ b/src/copas/timer.lua
@@ -1,5 +1,12 @@
 local copas = require("copas")
 
+local xpcall = xpcall
+local coroutine_running = coroutine.running
+
+if _VERSION=="Lua 5.1" and not jit then     -- obsolete: only for Lua 5.1 compatibility
+  xpcall = require("coxpcall").xpcall
+  coroutine_running = require("coxpcall").running
+end
 
 
 local timer = {}
@@ -18,6 +25,9 @@ end
 
 do
   local function expire_func(self, initial_delay)
+    if self.errorhandler then
+      copas.seterrorhandler(self.errorhandler)
+    end
     copas.sleep(initial_delay)
     while true do
       if not self.cancelled then
@@ -83,23 +93,36 @@ function timer:cancel()
 end
 
 
+do
+  -- xpcall error handler that forwards to the copas errorhandler
+  local ehandler = function(err_obj)
+    return copas.geterrorhandler()(err_obj, coroutine_running(), nil)
+  end
 
---- Creates a new timer object.
--- Note: the callback signature is: `function(timer_obj, params)`.
--- @param opts (table) `opts.delay` timer delay in seconds, `opts.callback` function to execute, `opts.recurring` boolean
--- `opts.params` (optional) this value will be passed to the timer callback, `opts.initial_delay` (optional) the first delay to use, defaults to `delay`.
--- @return timer object, or throws an error on bad input
-function timer.new(opts)
-  assert(opts.delay >= 0, "delay must be greater than or equal to 0")
-  assert(type(opts.callback) == "function", "expected callback to be a function")
-  return setmetatable({
-    name = opts.name or new_name(),
-    delay = opts.delay,
-    callback = opts.callback,
-    recurring = not not opts.recurring,
-    params = opts.params,
-    cancelled = false,
-  }, timer):arm(opts.initial_delay)
+
+  --- Creates a new timer object.
+  -- Note: the callback signature is: `function(timer_obj, params)`.
+  -- @param opts (table) `opts.delay` timer delay in seconds, `opts.callback` function to execute, `opts.recurring` boolean
+  -- `opts.params` (optional) this value will be passed to the timer callback, `opts.initial_delay` (optional) the first delay to use, defaults to `delay`.
+  -- @return timer object, or throws an error on bad input
+  function timer.new(opts)
+    assert(opts.delay >= 0, "delay must be greater than or equal to 0")
+    assert(type(opts.callback) == "function", "expected callback to be a function")
+
+    local callback = function(timer_obj, params)
+      xpcall(opts.callback, ehandler, timer_obj, params)
+    end
+
+    return setmetatable({
+      name = opts.name or new_name(),
+      delay = opts.delay,
+      callback = callback,
+      recurring = not not opts.recurring,
+      params = opts.params,
+      cancelled = false,
+      errorhandler = opts.errorhandler,
+    }, timer):arm(opts.initial_delay)
+  end
 end
 
 

--- a/tests/timer.lua
+++ b/tests/timer.lua
@@ -94,7 +94,34 @@ copas.loop(function()
   })
   -- succes count = 13
 
+  local count = 0
+  local params_in = {}
+  -- timer shouldn't be cancelled if its handler errors
+  timer.new({
+    name = "error-test",
+    delay = 0.1,
+    recurring = true,
+    params = params_in,
+    errorhandler = function(msg, co, skt)
+      local errmsg = copas.gettraceback(msg, co, skt)
+      assert(errmsg:find("error%-test"), "the threadname wasn't found")
+      assert(errmsg:find("error 1!") or errmsg:find("error 2!"), "the error message wasn't found")
+      --print(errmsg)
+      successes = successes + 1
+    end,
+    callback = function(timer_obj, params)
+      assert(params == params_in, "Params table wasn't passed along")
+      count = count + 1
+      if count == 2 then
+        -- 2nd call, so we're done
+        timer_obj:cancel()
+      end
+      error("error "..count.."!")
+    end,
+  })
+  -- succes count = 15
+
 end)
 
-assert(successes == 13, "number of successes didn't match! got: "..successes)
+assert(successes == 15, "number of successes didn't match! got: "..successes)
 print("test success!")


### PR DESCRIPTION
see changelog changes for exact changes. Adds;
- errorhandling for timers
- retrieving errorhandler for a coroutine
- renaming last camel-case functions (backward-compat in place)