### PR TITLE
fix(removethread): would not remove a sleeping thread immediately

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -100,6 +100,12 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
+    <dt><strong>Copas 4.7.x</strong> [unreleased]</dt>
+	<dd><ul>
+        <li>Fix: <code>copas.removethread</code> would not remove a sleeping thread immediately (it would not execute, but
+        would prevent the Copas loop from exiting until the timer expired).</li>
+    </ul></dd>
+
     <dt><strong>Copas 4.7.0</strong> [15/Jan/2023]</dt>
 	<dd><ul>
         <li>Fix: windows makefile didn't include all submodules.</li>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -788,7 +788,32 @@ servers.
     should only be used to wrap an explicit yield to the Copas scheduler. They
     should not be used to wrap user code.<br />
     <br />
-    For usage examples see the <code>lock</code> and <code>semaphore</code>
+    Example usage:
+<pre class="example">
+local copas = require "copas"
+local result = "nothing"
+
+copas(function()
+
+  local function timeout_handler(co)  -- co will be the coroutine from which 'timeout()' was called
+    print("executing timeout handler")
+    result = "timeout"
+    copas.removethread(co)            -- drop the thread, because we timed out
+  end
+
+  copas.addthread(function()
+    copas.timeout(5, timeout_handler) -- timeout on the current coroutine after 5 seconds
+    copas.pause(10)                   -- sleep for 10 seconds
+    print("just woke up")
+    result = "slept like a baby"
+    copas.timeout(0)                  -- cancel the timeout on the current coroutine
+  end)
+end)
+
+print("result: ", result)
+</pre>
+
+    For other usage examples see the <code>lock</code> and <code>semaphore</code>
     implementations.
     </dd>
 

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -288,6 +288,11 @@ local _sleeping = {} do
     end
   end
 
+  function _sleeping:cancel(co)
+    lethargy[co] = nil
+    heap:remove(co)
+  end
+
   -- @param tos number of timeouts running
   function _sleeping:done(tos)
     -- return true if we have nothing more to do
@@ -1301,6 +1306,7 @@ function copas.removethread(thread)
   -- if the specified coroutine is registered, add it to the canceled table so
   -- that next time it tries to resume it exits.
   _canceled[thread] = _threads[thread or 0]
+  _sleeping:cancel(thread)
 end
 
 

--- a/tests/removethread.lua
+++ b/tests/removethread.lua
@@ -4,7 +4,10 @@
 package.path = string.format("../src/?.lua;%s", package.path)
 
 local copas = require("copas")
---local socket = require("socket")
+local now = require("socket").gettime
+
+
+-- Test 1: basic test
 
 local t1 = copas.addthread(
     function()
@@ -42,4 +45,22 @@ collectgarbage()
 
 --check GC
 assert(next(validate_gc) == nil, "the 'validate_gc' table should have been empty!")
-print "test success!"
+print "test 1: success!"
+
+
+
+-- Test 2: ensure a waiting thread leaves in a timely manner
+
+local coro = copas.addthread(function()
+  copas.pause(2)
+end)
+
+local start_time = now()
+copas(function()
+  copas.pause(0.5)
+  copas.removethread(coro)
+end)
+local duration = now() - start_time
+
+assert(duration < 0.6, ("Expected immediate exit, after removal of thread, took: %.2f"):format(duration))
+print "test 2: success!"


### PR DESCRIPTION
The thread would be cancelled, but would remain in the timer-tree preventing Copas loop from exiting.