### PR TITLE
Update copas.settimeout

### DIFF
--- a/src/copas.lua
+++ b/src/copas.lua
@@ -478,6 +478,9 @@ end
 
 -- negative is indefinitly, nil means do not change
 function copas.settimeouts(skt, connect, send, read)
+  if type(skt) == "table" and type(skt.socket) == "userdata" then
+    skt = skt.socket
+  end
 
   if connect ~= nil and type(connect) ~= "number" then
     return nil, "connect timeout must be 'nil' or a number"


### PR DESCRIPTION
I used copas.settimeout after copas.wrap, but the socket was still being read endlessly until I printed the timeout table while copas is running and noticed that there were unwrapped sockets in the table

![screenshot_2023-11-22_10 17 55@2x](https://github.com/lunarmodules/copas/assets/9200174/12dd05e8-c18e-4181-9c25-4631dedc6dab)

![screenshot_2023-11-22_10 18 41@2x](https://github.com/lunarmodules/copas/assets/9200174/32976ef6-d94c-44f0-9a72-5e5da4ecfdb2)
