### PR TITLE
feat(cancelall): new method to cancel all pending work and exit

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -100,6 +100,12 @@ luarocks install copas
 
 <dl class="history">
 
+    <dt><strong>Copas 4.x.x</strong> [unreleased]</dt>
+	<dd><ul>
+        <li>Feat: added <code>copas.cancelall()</code>. It cancels pending work to force-exit the loop.
+        Intended use is for testing, to force a loop exit, even if a test fails.</li>
+    </ul></dd>
+
     <dt><strong>Copas 4.10.0</strong> [27/Mar/2026]</dt>
 	<dd><ul>
         <li>Feat: added <code>copas.future</code> class. Wraps a thread in a future, allowing other

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -1062,6 +1062,39 @@ print("result: ", result)
 
 <dl class="reference">
 
+    <dt><strong><code>copas.cancelall()</code></strong></dt>
+    <dd>
+        <p>This will clear pending work (client sockets, server sockets, timers) to force the copas
+            loop to exit immediately. This is useful for testing and debugging.
+        </p>
+
+        <p>Here's an example which, upon an error, cancels all pending work to ensure the test
+            ends immediately instead of waiting for the long sleep to end:
+        </p>
+        <pre class="example">
+local failure
+
+copas(function())
+  copas.seterrorhandler(function(msg, co, skt)
+    failure = copas.gettraceback(msg, co, skt)
+    copas.cancelall()   -- cancel all pending work to force exit
+  end, true)            -- true -&gt; set as default errorhandler
+
+  copas.addthread(function()
+    print("sleeping")
+    copas.pause(3600)   -- would block copas loop from exiting
+  end)
+
+  copas.addthread(function()
+    copas.pause(1)
+    error("boom!!")     -- invokes the erorrhandler above
+  end)
+end)
+
+assert(not failure, failure)
+        </pre>
+    </dd>
+
     <dt><strong><code>copas.debug.start([logger] [, core])</code></strong></dt>
     <dd>
         <p>This will internally replace coroutine handler functions to provide log output to

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -1721,30 +1721,24 @@ function copas.cancelall()
   -- 1. clear resumable queue
   _resumable:clear_resumelist()
 
-  -- 2. drain sleeping heap, re-insert internal timeout-timer so done() stays valid
+  -- 2. drain sleeping heap
   _sleeping:cancelall()
 
-  -- 3. close and drain reading sockets (snapshot to avoid mutate-while-iterate)
-  local socks = {}
-  for i = 1, #_reading do socks[i] = _reading[i] end
-  for _, skt in ipairs(socks) do
-    pcall(skt.close, skt)
-    _reading:remove(skt)
+  -- 3. close and drain reading sockets
+  while _reading[1] do
+    copas.close(_reading[1])
+    _reading:remove(_reading[1])
   end
 
   -- 4. close and drain writing sockets
-  socks = {}
-  for i = 1, #_writing do socks[i] = _writing[i] end
-  for _, skt in ipairs(socks) do
-    pcall(skt.close, skt)
-    _writing:remove(skt)
+  while _writing[1] do
+    copas.close(_writing[1])
+    _writing:remove(_writing[1])
   end
 
   -- 5. remove all servers
-  socks = {}
-  for i = 1, #_servers do socks[i] = _servers[i] end
-  for _, skt in ipairs(socks) do
-    copas.removeserver(skt)
+  while _servers[1] do
+    copas.removeserver(_servers[1])
   end
 
   -- 6. clear non-weak ancillary tables

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -43,6 +43,7 @@ local gettime = (socket or system).gettime
 local block_sleep = (socket or system).sleep
 local ssl -- only loaded upon demand
 
+local core_timer_thread
 local WATCH_DOG_TIMEOUT = 120
 local UDP_DATAGRAM_MAX = (socket or {})._DATAGRAMSIZE or 8192
 local TIMEOUT_PRECISION = 0.1  -- 100ms
@@ -312,9 +313,9 @@ local _sleeping = {} do
     heap:remove(co)
   end
 
-  function _sleeping:cancelall(protected_co)
+  function _sleeping:cancelall()
     while heap:size() > 0 do heap:pop() end
-    heap:insert(gettime() + TIMEOUT_PRECISION, protected_co)
+    heap:insert(gettime() + TIMEOUT_PRECISION, core_timer_thread)
     -- lethargy is weak; copas's idle GC sweeps will clean it within a few steps
   end
 
@@ -1380,28 +1381,23 @@ end
 -- Timeout management
 -------------------------------------------------------------------------------
 
-local _get_timeout_thread  -- forward declaration; assigned in the block below
-
 do
   local timeout_register = setmetatable({}, { __mode = "k" })
-  local time_out_thread
   local timerwheel = require("timerwheel").new({
       now = gettime,
       precision = TIMEOUT_PRECISION,
       ringsize = math.floor(60*60*24/TIMEOUT_PRECISION),  -- ring size 1 day
       err_handler = function(err)
-        return _deferror(err, time_out_thread)
+        return _deferror(err, core_timer_thread)
       end,
     })
 
-  time_out_thread = copas.addnamedthread("copas_core_timer", function()
+  core_timer_thread = copas.addnamedthread("copas_core_timer", function()
     while true do
       copas.pause(TIMEOUT_PRECISION)
       timerwheel:step()
     end
   end)
-
-  _get_timeout_thread = function() return time_out_thread end
 
   -- get the number of timeouts running
   function copas.gettimeouts()
@@ -1726,7 +1722,7 @@ function copas.cancelall()
   _resumable:clear_resumelist()
 
   -- 2. drain sleeping heap, re-insert internal timeout-timer so done() stays valid
-  _sleeping:cancelall(_get_timeout_thread())
+  _sleeping:cancelall()
 
   -- 3. close and drain reading sockets (snapshot to avoid mutate-while-iterate)
   local socks = {}

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -312,6 +312,12 @@ local _sleeping = {} do
     heap:remove(co)
   end
 
+  function _sleeping:cancelall(protected_co)
+    while heap:size() > 0 do heap:pop() end
+    heap:insert(gettime() + TIMEOUT_PRECISION, protected_co)
+    -- lethargy is weak; copas's idle GC sweeps will clean it within a few steps
+  end
+
   -- @param tos number of timeouts running
   function _sleeping:done(tos)
     -- return true if we have nothing more to do
@@ -1374,6 +1380,8 @@ end
 -- Timeout management
 -------------------------------------------------------------------------------
 
+local _get_timeout_thread  -- forward declaration; assigned in the block below
+
 do
   local timeout_register = setmetatable({}, { __mode = "k" })
   local time_out_thread
@@ -1392,6 +1400,8 @@ do
       timerwheel:step()
     end
   end)
+
+  _get_timeout_thread = function() return time_out_thread end
 
   -- get the number of timeouts running
   function copas.gettimeouts()
@@ -1703,6 +1713,51 @@ local resetexit do
   function copas.waitforexit()
     exit_semaphore:take(1)
   end
+end
+
+
+--- Forcibly cancels all pending work and signals exit.
+-- Intended for test teardown only. Abandons all registered threads and sockets
+-- without giving them a chance to clean up. After this call copas.finished()
+-- will return true and the loop will exit. The module is left in a clean state
+-- ready for the next copas.loop() call.
+function copas.cancelall()
+  -- 1. clear resumable queue
+  _resumable:clear_resumelist()
+
+  -- 2. drain sleeping heap, re-insert internal timeout-timer so done() stays valid
+  _sleeping:cancelall(_get_timeout_thread())
+
+  -- 3. close and drain reading sockets (snapshot to avoid mutate-while-iterate)
+  local socks = {}
+  for i = 1, #_reading do socks[i] = _reading[i] end
+  for _, skt in ipairs(socks) do
+    pcall(skt.close, skt)
+    _reading:remove(skt)
+  end
+
+  -- 4. close and drain writing sockets
+  socks = {}
+  for i = 1, #_writing do socks[i] = _writing[i] end
+  for _, skt in ipairs(socks) do
+    pcall(skt.close, skt)
+    _writing:remove(skt)
+  end
+
+  -- 5. remove all servers
+  socks = {}
+  for i = 1, #_servers do socks[i] = _servers[i] end
+  for _, skt in ipairs(socks) do
+    copas.removeserver(skt)
+  end
+
+  -- 6. clear non-weak ancillary tables
+  _closed = {}
+  _reading_log = {}
+  _writing_log = {}
+
+  -- 7. signal exit
+  copas.exit()
 end
 
 

--- a/tests/cancelall.lua
+++ b/tests/cancelall.lua
@@ -1,0 +1,60 @@
+-- make sure we are pointing to the local copas first
+package.path = string.format("../src/?.lua;%s", package.path)
+
+local copas = require "copas"
+local socket = require "socket"
+local timer = copas.timer
+
+-- Test 1: cancelall() exits a loop that has a server, a sleeping thread, and a
+-- thread blocked on a socket.
+
+local loop1_exited = false
+
+copas.loop(function()
+  -- register a server that will never get a connection
+  local srv = socket.tcp()
+  assert(srv:bind("127.0.0.1", 0))
+  srv:listen(5)
+  copas.addserver(srv, function() end)
+
+  -- register a thread that sleeps forever
+  copas.addthread(function()
+    copas.sleep(math.huge)
+  end)
+
+  -- register a thread that waits on a socket read (connect to our own server)
+  local port = select(2, srv:getsockname())
+  copas.addthread(function()
+    local client = copas.wrap(socket.tcp())
+    client:connect("127.0.0.1", port)
+    client:receive("*l")  -- blocks waiting for data that never arrives
+  end)
+
+  -- fire cancelall after a short delay
+  timer.new({
+    delay = 0.1,
+    callback = function()
+      copas.cancelall()
+    end,
+  })
+end)
+
+loop1_exited = true
+print("loop 1 exited ok")
+
+-- Test 2: after cancelall(), a fresh copas.loop() works correctly.
+
+local loop2_done = false
+
+copas.loop(function()
+  copas.addthread(function()
+    copas.sleep(0.05)
+    loop2_done = true
+  end)
+end)
+
+assert(loop2_done, "loop 2 did not complete its task")
+print("loop 2 exited ok")
+
+assert(loop1_exited)
+print("all tests passed")

--- a/tests/cancelall.lua
+++ b/tests/cancelall.lua
@@ -8,22 +8,21 @@ local timer = copas.timer
 -- Test 1: cancelall() exits a loop that has a server, a sleeping thread, and a
 -- thread blocked on a socket.
 
-local loop1_exited = false
-
 copas.loop(function()
   -- register a server that will never get a connection
   local srv = socket.tcp()
-  assert(srv:bind("127.0.0.1", 0))
-  srv:listen(5)
-  copas.addserver(srv, function() end)
+  assert(srv:bind("127.0.0.1", 0, 5))
+  copas.addserver(srv, function()
+    copas.pause(60*60) -- don't handle incoming connections, let them wait
+  end)
 
   -- register a thread that sleeps forever
   copas.addthread(function()
-    copas.sleep(math.huge)
+    copas.pause(60*60)
   end)
 
   -- register a thread that waits on a socket read (connect to our own server)
-  local port = select(2, srv:getsockname())
+  local _, port = srv:getsockname()
   copas.addthread(function()
     local client = copas.wrap(socket.tcp())
     client:connect("127.0.0.1", port)
@@ -32,14 +31,22 @@ copas.loop(function()
 
   -- fire cancelall after a short delay
   timer.new({
-    delay = 0.1,
+    delay = 0.5,
     callback = function()
       copas.cancelall()
     end,
   })
+
+  -- set up a timeout timer to make sure the loop exits within a reasonable time
+  timer.new({
+    delay = 5,
+    callback = function()
+      print("loop 1 did not exit within 5 seconds")
+      os.exit(1) -- exit with error code to indicate failure
+    end,
+  })
 end)
 
-loop1_exited = true
 print("loop 1 exited ok")
 
 -- Test 2: after cancelall(), a fresh copas.loop() works correctly.
@@ -56,5 +63,4 @@ end)
 assert(loop2_done, "loop 2 did not complete its task")
 print("loop 2 exited ok")
 
-assert(loop1_exited)
 print("all tests passed")

--- a/tests/cancelall.lua
+++ b/tests/cancelall.lua
@@ -55,7 +55,7 @@ local loop2_done = false
 
 copas.loop(function()
   copas.addthread(function()
-    copas.sleep(0.05)
+    copas.pause(0.05)
     loop2_done = true
   end)
 end)


### PR DESCRIPTION
adds a new way to force-exit the copas loop. This is intended for testing client libraries and/or applications running on top of Copas.