### PR TITLE
fix(timeout): clear stale socket timeout state after timeout

### DIFF
--- a/src/copas.lua
+++ b/src/copas.lua
@@ -571,6 +571,7 @@ function copas.receive(client, pattern, part)
 
     elseif sto_timed_out() then
       current_log[client] = nil
+      sto_timeout()
       return nil, sto_error(err), part
     end
 
@@ -615,6 +616,7 @@ function copas.receivefrom(client, size)
 
     elseif sto_timed_out() then
       _reading_log[client] = nil
+      sto_timeout()
       return nil, sto_error(err), port
     end
 
@@ -652,6 +654,7 @@ function copas.receivepartial(client, pattern, part)
 
     elseif sto_timed_out() then
       current_log[client] = nil
+      sto_timeout()
       return nil, sto_error(err), part
     end
 
@@ -700,6 +703,7 @@ function copas.send(client, data, from, to)
 
     elseif sto_timed_out() then
       current_log[client] = nil
+      sto_timeout()
       return nil, sto_error(err), lastIndex
     end
 
@@ -748,6 +752,7 @@ function copas.connect(skt, host, port)
 
     elseif sto_timed_out() then
       _writing_log[skt] = nil
+      sto_timeout()
       return nil, sto_error(err)
     end
 
@@ -872,6 +877,7 @@ function copas.dohandshake(skt, wrap_params)
       error("TLS/SSL handshake failed: " .. tostring(err))
 
     elseif sto_timed_out() then
+      sto_timeout()
       return nil, sto_error(err)
 
     elseif err == "wantwrite" then

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -464,6 +464,13 @@ local sto_timeout, sto_timed_out, sto_change_queue, sto_error do
   function sto_error(err)
     return useSocketTimeoutErrors[coroutine_running()] and err or "timeout"
   end
+
+  -- only in case of testing export some internals
+  if _G._TEST then
+    copas._socket_register = socket_register
+    copas._operation_register = operation_register
+    copas._timeout_flags = timeout_flags
+  end
 end
 
 

--- a/tests/tcptimeout.lua
+++ b/tests/tcptimeout.lua
@@ -29,6 +29,36 @@ local function assert(truthy, err)
   end
 end
 
+local function get_socket_timeout_tables()
+  local sto_timeout
+
+  for i = 1, math.huge do
+    local name, value = debug.getupvalue(copas.receive, i)
+    if not name then break end
+    if name == "sto_timeout" then
+      sto_timeout = value
+      break
+    end
+  end
+
+  assert(sto_timeout, "could not find sto_timeout upvalue")
+
+  local tables = {}
+  for i = 1, math.huge do
+    local name, value = debug.getupvalue(sto_timeout, i)
+    if not name then break end
+    if name == "socket_register" or name == "operation_register" or name == "timeout_flags" then
+      tables[name] = value
+    end
+  end
+
+  assert(tables.socket_register, "could not find socket_register upvalue")
+  assert(tables.operation_register, "could not find operation_register upvalue")
+  assert(tables.timeout_flags, "could not find timeout_flags upvalue")
+
+  return tables
+end
+
 -- tcp echo server for testing against, returns `ip, port` to connect to
 -- send `quit\n` to cause server to disconnect client
 -- stops listen server after first connection
@@ -155,6 +185,44 @@ function tests.receive_timeout()
   end)
 
   copas.loop()
+end
+
+
+function tests.receive_timeout_clears_copas_timeout()
+  local timeout_tables = get_socket_timeout_tables()
+  local server = socket.bind("127.0.0.1", 0)
+  local ip, port = server:getsockname()
+  local handler_co
+
+  copas.addserver(server, function(skt)
+    handler_co = coroutine.running()
+    copas.removeserver(server)
+
+    skt = copas.wrap(skt)
+    skt:settimeout(0.01)
+
+    local data, err = skt:receive()
+    assert(data == nil, "somehow recieved data without the client sending")
+    assert(err == "timeout", "failed with non-timeout error: "..tostring(err))
+
+    skt:close()
+  end)
+
+  copas.addthread(function()
+    local client = socket.tcp()
+    local status, err = client:connect(ip, port)
+    assert(status, "failed to connect: "..tostring(err))
+
+    copas.pause(0.25)
+    client:close()
+  end)
+
+  copas.loop()
+
+  assert(handler_co, "server handler did not run")
+  assert(timeout_tables.socket_register[handler_co] == nil, "socket_register kept the timed-out coroutine")
+  assert(timeout_tables.operation_register[handler_co] == nil, "operation_register kept the timed-out coroutine")
+  assert(timeout_tables.timeout_flags[handler_co] == nil, "timeout_flags kept the timed-out coroutine")
 end
 
 -- test "framework"

--- a/tests/tcptimeout.lua
+++ b/tests/tcptimeout.lua
@@ -14,6 +14,7 @@ end
 print("Testing platform: " .. platform)
 
 
+_G._TEST = true -- mark as test, to export some internals for testing
 local copas = require("copas")
 local socket = require("socket")
 
@@ -27,36 +28,6 @@ local function assert(truthy, err)
     print(debug.traceback(err, 2))
     os.exit(-1)
   end
-end
-
-local function get_socket_timeout_tables()
-  local sto_timeout
-
-  for i = 1, math.huge do
-    local name, value = debug.getupvalue(copas.receive, i)
-    if not name then break end
-    if name == "sto_timeout" then
-      sto_timeout = value
-      break
-    end
-  end
-
-  assert(sto_timeout, "could not find sto_timeout upvalue")
-
-  local tables = {}
-  for i = 1, math.huge do
-    local name, value = debug.getupvalue(sto_timeout, i)
-    if not name then break end
-    if name == "socket_register" or name == "operation_register" or name == "timeout_flags" then
-      tables[name] = value
-    end
-  end
-
-  assert(tables.socket_register, "could not find socket_register upvalue")
-  assert(tables.operation_register, "could not find operation_register upvalue")
-  assert(tables.timeout_flags, "could not find timeout_flags upvalue")
-
-  return tables
 end
 
 -- tcp echo server for testing against, returns `ip, port` to connect to
@@ -189,7 +160,6 @@ end
 
 
 function tests.receive_timeout_clears_copas_timeout()
-  local timeout_tables = get_socket_timeout_tables()
   local server = socket.bind("127.0.0.1", 0)
   local ip, port = server:getsockname()
   local handler_co
@@ -220,9 +190,9 @@ function tests.receive_timeout_clears_copas_timeout()
   copas.loop()
 
   assert(handler_co, "server handler did not run")
-  assert(timeout_tables.socket_register[handler_co] == nil, "socket_register kept the timed-out coroutine")
-  assert(timeout_tables.operation_register[handler_co] == nil, "operation_register kept the timed-out coroutine")
-  assert(timeout_tables.timeout_flags[handler_co] == nil, "timeout_flags kept the timed-out coroutine")
+  assert(copas._socket_register[handler_co] == nil, "socket_register kept the timed-out coroutine")
+  assert(copas._operation_register[handler_co] == nil, "operation_register kept the timed-out coroutine")
+  assert(copas._timeout_flags[handler_co] == nil, "timeout_flags kept the timed-out coroutine")
 end
 
 -- test "framework"

--- a/tests/tcptimeout.lua
+++ b/tests/tcptimeout.lua
@@ -160,6 +160,7 @@ end
 
 
 function tests.receive_timeout_clears_copas_timeout()
+  -- See issue https://github.com/lunarmodules/copas/issues/185
   local server = socket.bind("127.0.0.1", 0)
   local ip, port = server:getsockname()
   local handler_co


### PR DESCRIPTION
Fixes #185.

This clears the current socket timeout state before returning from `sto_timed_out()` branches. The success and non-timeout error paths already do this via `sto_timeout()`; this makes the timeout paths consistent with those exits.

Covered paths:

- `receive`
- `receivefrom`
- `receivepartial`
- `send`
- `connect`
- `dohandshake`

Tested with:

```text
luajit tests/tcptimeout.lua
luajit tests/udptimeout.lua
luajit tests/timeout_errors.lua
```

Note: the regression test enables `_G._TEST` before requiring Copas so the socket timeout bookkeeping tables are exported only during test runs.
