### PR TITLE
fix(lock): skip canceled queue waiters instead of deadlocking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ test: certs
 	$(LUA) $(DELIM) $(PKGPATH) tests/timeout_errors.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/tls-sni.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/udptimeout.lua
+	$(LUA) $(DELIM) $(PKGPATH) tests/wakeup.lua
 	$(LUA) $(DELIM)
 
 coverage:

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -399,11 +399,14 @@ exchange data with other services.</p>
         <p><i>Deprecated:</i> use <code>copas.pause</code> and <code>copas.pauseforever</code> instead.</p>
     </dd>
 
-    <dt><strong><code>copas.wakeup(co)</code></strong></dt>
+    <dt><strong><code>ok, err = copas.wakeup(co)</code></strong></dt>
     <dd>
         <p>Immediately wakes up a coroutine that was sleeping or sleeping-forever.
         <code>co</code> is the coroutine to wakeup, see <code>copas.pause()</code>
-        and <code>copas.pauseforever()</code>. Does nothing if the coroutine wasn't sleeping.</p>
+        and <code>copas.pauseforever()</code>.</p>
+        <p>Returns <code>true</code> on success, or <code>nil + "not sleeping"</code> if the
+        coroutine wasn't sleeping (eg. it already finished, was already woken up, or was
+        canceled through <code>copas.removethread()</code>).</p>
     </dd>
 
     <dt><strong><code>sock:close()</code></strong></dt>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -409,6 +409,14 @@ exchange data with other services.</p>
         canceled through <code>copas.removethread()</code>).</p>
     </dd>
 
+    <dt><strong><code>bool = copas.issleeping(co)</code></strong></dt>
+    <dd>
+        <p>Checks whether <code>co</code> is currently sleeping (paused or paused-forever),
+        without waking it up. Useful for code that queues coroutines and later needs to tell
+        a still-legitimately-waiting coroutine apart from one that was canceled in the
+        meantime (eg. through <code>copas.removethread()</code>) while it was queued.</p>
+    </dd>
+
     <dt><strong><code>sock:close()</code></strong></dt>
     <dd>
         <p>Equivalent to the LuaSocket method (after <code>copas.wrap</code>).</p>

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -301,11 +301,13 @@ local _sleeping = {} do
     if lethargy[co] then
       lethargy[co] = nil
       _resumable:push(co)
-      return
+      return true
     end
     if heap:remove(co) then
       _resumable:push(co)
+      return true
     end
+    return nil, "not sleeping"
   end
 
   function _sleeping:cancel(co)
@@ -1392,8 +1394,10 @@ end
 
 
 -- Wakes up a sleeping coroutine 'co'.
+-- @return true on success, or nil+"not sleeping" if 'co' wasn't sleeping
+-- (eg. it was already woken up, finished, or canceled through `copas.removethread`).
 function copas.wakeup(co)
-  _sleeping:wakeup(co)
+  return _sleeping:wakeup(co)
 end
 
 

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -310,6 +310,14 @@ local _sleeping = {} do
     return nil, "not sleeping"
   end
 
+  -- non-destructive check; unlike wakeup/cancel it doesn't remove 'co'
+  function _sleeping:issleeping(co)
+    if lethargy[co] then
+      return true
+    end
+    return heap:valueByPayload(co) ~= nil
+  end
+
   function _sleeping:cancel(co)
     lethargy[co] = nil
     heap:remove(co)
@@ -1398,6 +1406,15 @@ end
 -- (eg. it was already woken up, finished, or canceled through `copas.removethread`).
 function copas.wakeup(co)
   return _sleeping:wakeup(co)
+end
+
+
+-- Checks whether a coroutine 'co' is currently sleeping (paused or
+-- paused-forever), without waking it up. Useful to detect a coroutine
+-- that was canceled (eg. through `copas.removethread`) while it was
+-- expected to still be waiting.
+function copas.issleeping(co)
+  return _sleeping:issleeping(co)
 end
 
 

--- a/src/copas/lock.lua
+++ b/src/copas/lock.lua
@@ -172,17 +172,18 @@ function lock:release()
   end
 
   -- need a loop, since individual coroutines might have been removed
-  -- so there might be holes
+  -- (or canceled externally, eg. via `copas.removethread`/`future:cancel`)
+  -- so there might be holes, or stale entries whose wakeup will fail
   while self.q_tip < self.q_tail do
     local next_up = self.queue[self.q_tip]
-    if next_up then
+    self.queue[self.q_tip] = nil
+    self.q_tip = self.q_tip + 1
+    if next_up and copas.wakeup(next_up) then
       self.owner = next_up
-      self.queue[self.q_tip] = nil
-      self.q_tip = self.q_tip + 1
-      copas.wakeup(next_up)
       return true
     end
-    self.q_tip = self.q_tip + 1
+    -- either an empty hole, or 'next_up' was canceled and will never resume
+    -- to release the lock itself, so move on to the next waiter in line
   end
   -- queue is empty, reset pointers
   self.owner = nil

--- a/src/copas/semaphore.lua
+++ b/src/copas/semaphore.lua
@@ -83,18 +83,26 @@ function semaphore:give(given)
     local nxt = self.queue[i] -- there can be holes, so nxt might be nil
     if not nxt then
       self.q_tip = i + 1
+    elseif not copas.issleeping(nxt.co) then
+      -- stale entry; 'nxt.co' was canceled externally (eg. via
+      -- copas.removethread/future:cancel) and will never resume to
+      -- consume or give back resources. Drop it without touching 'count',
+      -- and regardless of how much it had requested, so it doesn't block
+      -- waiters behind it that request less than it did.
+      self.queue[i] = nil
+      self.to_flags[nxt.co] = nil
+      self.q_tip = i + 1
+      nxt.co = nil
+    elseif count >= nxt.requested then
+      -- release it
+      self.queue[i] = nil
+      self.to_flags[nxt.co] = nil
+      count = count - nxt.requested
+      self.q_tip = i + 1
+      copas.wakeup(nxt.co)
+      nxt.co = nil
     else
-      if count >= nxt.requested then
-        -- release it
-        self.queue[i] = nil
-        self.to_flags[nxt.co] = nil
-        count = count - nxt.requested
-        self.q_tip = i + 1
-        copas.wakeup(nxt.co)
-        nxt.co = nil
-      else
-        break -- we ran out of resources
-      end
+      break -- we ran out of resources
     end
   end
 

--- a/tests/lock.lua
+++ b/tests/lock.lua
@@ -104,4 +104,46 @@ copas.loop(function()
 end)
 assert(test_complete, "test did not complete!")
 
+
+-- Test 2: canceling a queued waiter must not permanently transfer ownership
+-- to it, locking out every legitimate waiter behind it forever.
+-- See https://github.com/lunarmodules/copas/issues/199
+local test2_complete = false
+copas.loop(function()
+
+  local lock2 = assert(Lock.new(5))
+  assert(lock2:get()) -- owned by this (the main) coroutine
+
+  -- queue a waiter that will be canceled (eg. via future:cancel()) while
+  -- it is still waiting in line for the lock
+  local canceled_co = copas.addthread(function()
+    lock2:get()
+  end)
+
+  -- queue a legitimate waiter behind it
+  local waiter_result
+  copas.addthread(function()
+    local ok, err = lock2:get()
+    waiter_result = ok and "got it" or err
+    if ok then
+      assert(lock2:release())
+    end
+  end)
+
+  copas.pause(0.1) -- let both threads enqueue behind the lock
+
+  copas.removethread(canceled_co) -- simulate external cancellation
+
+  assert(lock2:release()) -- should hand the lock to the legitimate waiter
+
+  copas.pause(0.1)
+
+  assert(waiter_result == "got it",
+    "expected the legitimate waiter to get the lock, got: "..tostring(waiter_result))
+  assert(lock2.owner == nil, "expected the lock to be free again")
+
+  test2_complete = true
+end)
+assert(test2_complete, "test 2 did not complete!")
+
 print("test success!")

--- a/tests/semaphore.lua
+++ b/tests/semaphore.lua
@@ -143,4 +143,78 @@ copas.loop(function()
   test_complete = true
 end)
 assert(test_complete, "test did not complete!")
+
+
+-- Test 2: canceling a queued waiter must not permanently leak the
+-- resources handed to it, nor starve legitimate waiters behind it.
+-- See https://github.com/lunarmodules/copas/issues/199 (same root cause
+-- as the copas.lock bug: `copas.wakeup()` failures were ignored).
+local test2_complete = false
+copas.loop(function()
+
+  -- 2a: a lone canceled waiter must not leak the resources given to it
+  local sema2 = semaphore.new(10, 0, 5)
+  local canceled_co = copas.addthread(function()
+    sema2:take(5)
+  end)
+  copas.pause(0.1) -- let it enqueue
+
+  copas.removethread(canceled_co) -- simulate external cancellation
+
+  assert(sema2:give(5))
+  copas.pause(0.1)
+
+  assert(sema2:get_count() == 5,
+    "expected the 5 given resources to remain available, got: "..tostring(sema2:get_count()))
+
+  -- 2b: a legitimate waiter behind a canceled one must still be served
+  local sema3 = semaphore.new(10, 0, 5)
+  local canceled_co2 = copas.addthread(function()
+    sema3:take(5)
+  end)
+  local waiter_result
+  copas.addthread(function()
+    local ok, err = sema3:take(5)
+    waiter_result = ok and "got it" or err
+  end)
+  copas.pause(0.1) -- let both enqueue
+
+  copas.removethread(canceled_co2) -- simulate external cancellation
+
+  assert(sema3:give(5))
+  copas.pause(0.1)
+
+  assert(waiter_result == "got it",
+    "expected the legitimate waiter to be served, got: "..tostring(waiter_result))
+
+  -- 2c: a canceled waiter requesting MORE than what's available must not
+  -- block a legitimate waiter behind it that requests less; the canceled
+  -- entry has to be dropped regardless of resource sufficiency, not just
+  -- when there happen to be enough resources to satisfy its own request.
+  local sema4 = semaphore.new(10, 0, 5)
+  local canceled_co3 = copas.addthread(function()
+    sema4:take(2) -- will be canceled while waiting for 2
+  end)
+  local waiter_result2
+  copas.addthread(function()
+    local ok, err = sema4:take(1) -- only needs 1
+    waiter_result2 = ok and "got it" or err
+  end)
+  copas.pause(0.1) -- let both enqueue
+
+  copas.removethread(canceled_co3) -- simulate external cancellation
+
+  assert(sema4:give(1)) -- not enough for the canceled request (2), plenty for the real one (1)
+  copas.pause(0.1)
+
+  assert(waiter_result2 == "got it",
+    "expected the smaller legitimate waiter to be served ahead of a stale bigger request, got: "
+    ..tostring(waiter_result2))
+  assert(sema4:get_count() == 0,
+    "expected the 1 given resource to have gone to the waiter, got: "..tostring(sema4:get_count()))
+
+  test2_complete = true
+end)
+assert(test2_complete, "test 2 did not complete!")
+
 print("test success!")

--- a/tests/wakeup.lua
+++ b/tests/wakeup.lua
@@ -1,0 +1,53 @@
+-- Test for copas.wakeup() return value.
+-- See https://github.com/lunarmodules/copas/issues/199
+--
+-- copas.wakeup() must report whether it actually woke a coroutine, so
+-- callers (eg. copas.lock) can tell a stale/canceled coroutine from a
+-- successfully woken one instead of assuming success unconditionally.
+
+-- make sure we are pointing to the local copas first
+package.path = string.format("../src/?.lua;%s", package.path)
+
+local copas = require "copas"
+
+local test_complete = false
+copas.loop(function()
+
+  -- waking a coroutine that is actually paused succeeds
+  local resumed = false
+  local co = copas.addthread(function()
+    copas.pauseforever()
+    resumed = true
+  end)
+  copas.pause() -- let 'co' actually reach pauseforever() before waking it
+  local ok, err = copas.wakeup(co)
+  assert(ok == true, "expected wakeup to return true, got: "..tostring(ok)..", "..tostring(err))
+  copas.pause(0.1)
+  assert(resumed, "expected the woken thread to have resumed")
+
+  -- waking it again (it's no longer sleeping) fails
+  local ok2, err2 = copas.wakeup(co)
+  assert(ok2 == nil, "expected re-waking a finished coroutine to fail")
+  assert(type(err2) == "string", "expected an error message, got: "..tostring(err2))
+
+  -- waking a coroutine that was canceled (eg. copas.removethread, or
+  -- future:cancel()) while sleeping fails, instead of silently no-op'ing
+  local co2 = copas.addthread(function()
+    copas.pauseforever()
+  end)
+  copas.removethread(co2)
+  local ok3, err3 = copas.wakeup(co2)
+  assert(ok3 == nil, "expected wakeup of a canceled coroutine to fail")
+  assert(type(err3) == "string", "expected an error message, got: "..tostring(err3))
+
+  -- waking a coroutine copas doesn't know about at all fails
+  local co3 = coroutine.create(function() end)
+  local ok4, err4 = copas.wakeup(co3)
+  assert(ok4 == nil, "expected wakeup of an unrelated coroutine to fail")
+  assert(type(err4) == "string", "expected an error message, got: "..tostring(err4))
+
+  test_complete = true
+end)
+assert(test_complete, "test did not complete!")
+
+print("test success!")


### PR DESCRIPTION
copas.wakeup() silently did nothing when its target coroutine wasn't actually sleeping (already resumed, finished, or canceled via copas.removethread()/future:cancel()). copas.lock:release() relied on it unconditionally: canceling a queued waiter permanently handed lock ownership to a coroutine that would never run, deadlocking every subsequent lock:get() call.

copas.wakeup() now returns true on success, or nil + "not sleeping" on failure, so lock:release() can skip stale/canceled queue entries and hand the lock to the next real waiter instead.

Fixes #199