### PR TITLE
fix(future): remove 9999-waiter cap on future completion

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -755,6 +755,7 @@ exchange data with other services.</p>
         <p>Creates and returns a new semaphore (fifo).</p>
 
         <p><code>max</code> specifies the maximum number of resources the semaphore can hold.
+        Use <code>math.huge</code> to not limit the number of resources.
         The optional <code>start</code> parameter (default 0) specifies the number of resources upon creation.</p>
 
         <p>The <code>timeout</code> specifies the default timeout for the semaphore in

--- a/src/copas/future.lua
+++ b/src/copas/future.lua
@@ -42,7 +42,7 @@ future.__call = function(self, ...) return self:get(...) end
 local function new_future()
   local self = setmetatable({
     results = nil, -- results will be stored here in a 'packed' table (pcall-style: true/false prefix)
-    sema = semaphore.new(9999, 0, math.huge),
+    sema = semaphore.new(math.huge, 0, math.huge),
     coro = nil -- the coroutine that will execute the task
   }, future)
 


### PR DESCRIPTION
The semaphore backing a future was capped at 9999, but give() truncates grants at that cap. With more than 9999 concurrent get() waiters on a single future, completion/cancellation left the excess waiters stranded forever since only 9999 permits were released.

The cap served no real purpose: get() only touches the semaphore while results are pending, and give() is called exactly once with the exact shortfall, so the semaphore is a one-shot wake-a-crowd mechanism, not a bounded resource pool. Using math.huge removes the ceiling so every queued waiter is released regardless of count.

Fixes #203