### PR TITLE
fix(timer): cancel() must not abandon an in-flight callback

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -822,7 +822,8 @@ exchange data with other services.</p>
 
     <dt><strong><code>timer:cancel()</code></strong></dt>
     <dd>
-        <p>Will cancel the timer.</p>
+        <p>Will cancel the timer. If the callback is currently in progress then the callback won't be
+        cancelled, just new invocations will be prevented.</p>
     </dd>
 
 </dl>

--- a/src/copas/timer.lua
+++ b/src/copas/timer.lua
@@ -75,6 +75,10 @@ end
 
 
 --- Cancels a running timer.
+-- If the timer callback is currently in progress (eg. yielded on socket I/O),
+-- it is allowed to run to completion, it just won't be rescheduled. Only a
+-- timer that is idle, waiting for its next recurrence, is woken up and
+-- stopped immediately.
 -- @return timer object, or nil+error
 function timer:cancel()
   if not self.co then
@@ -86,8 +90,7 @@ function timer:cancel()
   end
 
   self.cancelled = true
-  copas.wakeup(self.co)       -- resume asap
-  copas.removethread(self.co) -- will immediately drop the thread upon resuming
+  copas.wakeup(self.co) -- in case it's idle between recurrences, exit immediately
   self.co = nil
   return self
 end

--- a/tests/timer.lua
+++ b/tests/timer.lua
@@ -4,6 +4,7 @@ package.path = string.format("../src/?.lua;%s", package.path)
 
 
 local copas = require "copas"
+local socket = require "socket"
 local gettime = copas.gettime
 local timer = copas.timer
 
@@ -121,7 +122,54 @@ copas.loop(function()
   })
   -- succes count = 15
 
+  -- Regression test for https://github.com/lunarmodules/copas/issues/206
+  -- Cancelling a recurring timer while its callback is yielded on socket I/O
+  -- must let the in-progress callback resume and finish (just without
+  -- rescheduling), not abandon it mid-flight.
+  do
+    local io_invocations = 0
+    local io_callback_finished = false
+
+    local receiver = socket.udp()
+    receiver:setsockname("127.0.0.1", 0)
+    local ip, port = receiver:getsockname()
+    receiver = copas.wrap(receiver)
+
+    local io_timer
+    io_timer = timer.new({
+      delay = 0.1,
+      recurring = true,
+      callback = function()
+        io_invocations = io_invocations + 1
+        local data = receiver:receive()  -- yields on socket I/O
+        assert(data == "wakeup", "expected to receive 'wakeup', got: "..tostring(data))
+        io_callback_finished = true
+      end,
+    })
+
+    copas.addthread(function()
+      -- wait until the timer callback is parked waiting on the socket read
+      while io_invocations == 0 do
+        copas.pause(0.01)
+      end
+      copas.pause(0.05) -- make sure it actually reached the yield point
+
+      assert(io_timer:cancel())
+
+      local sender = copas.wrap(socket.udp())
+      sender:sendto("wakeup", ip, port)
+
+      copas.pause(0.2) -- allow the in-progress callback to resume and finish
+      assert(io_callback_finished, "in-progress callback was abandoned after cancel()")
+      successes = successes + 1  -- 1 to come
+
+      assert(io_invocations == 1, "timer rescheduled after being cancelled")
+      successes = successes + 1  -- 1 to come
+    end)
+  end
+  -- succes count = 17
+
 end)
 
-assert(successes == 15, "number of successes didn't match! got: "..successes)
+assert(successes == 17, "number of successes didn't match! got: "..successes)
 print("test success!")


### PR DESCRIPTION
cancel() called copas.removethread(self.co) unconditionally, which marks the coroutine canceled regardless of what queue it is parked in. If a recurring timer's callback was mid-flight on socket I/O (yielded into the reading/writing set), the dispatcher would see the cancel flag on the next resume and drop the coroutine instead of resuming it, abandoning the callback before it could finish.

The existing self.cancelled check already stops the timer from rescheduling once the callback returns, so removethread() was never needed for that. Dropping it, and keeping only wakeup() (which interrupts an idle timer waiting between recurrences), lets an in-progress callback run to completion while still cancelling promptly when the timer is idle.

Fixes #206