### PR TITLE
fix(tls): reject sslparams tables that silently disable TLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ test: certs
 	$(LUA) $(DELIM) $(PKGPATH) tests/tcptimeout.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/timer.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/timeout_errors.lua
+	$(LUA) $(DELIM) $(PKGPATH) tests/tls-params.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/tls-sni.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/udptimeout.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/wakeup.lua

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -917,15 +917,19 @@ local function normalize_sslt(sslt)
     r.sni = false
 
   elseif t == "table" then
-    if sslt.mode or sslt.protocol then
-      -- has the mandatory fields for the ssl-params table for handshake
-      -- backward compatibility
-      r.wrap = sslt
-      r.sni = false
-    else
-      -- has the target definition, copy our known keys
+    if sslt.wrap or sslt.sni then
+      -- has the target definition (current format), copy our known keys
       r.wrap = sslt.wrap or false -- 'or false' because we do not want nils
       r.sni = sslt.sni or false -- 'or false' because we do not want nils
+    else
+      -- neither of our own keys is truthy, so treat it as a flat luasec
+      -- context/wrap-params table (backward compatibility), or garbage.
+      -- There are no default TLS settings, so we cannot detect/reject a bad
+      -- table here. But we do not need to; LuaSec validates its mandatory
+      -- fields (mode, protocol, etc.) itself and throws on anything
+      -- incomplete, so this can never fail open into silent plaintext.
+      r.wrap = sslt
+      r.sni = false
     end
 
   elseif t == "userdata" then
@@ -1173,7 +1177,8 @@ _skt_mt_udp.__index.settimeouts = function (self, connect, send, receive)
 ---
 -- Wraps a LuaSocket socket object in an async Copas based socket object.
 -- @param skt The socket to wrap
--- @sslt (optional) Table with ssl parameters, use an empty table to use ssl with defaults
+-- @param[opt] sslt Table with ssl parameters (see 'sslparams' in the reference docs).
+-- Omit the parameter to disable TLS entirely.
 -- @return wrapped socket object
 function copas.wrap (skt, sslt)
   if (getmetatable(skt) == _skt_mt_tcp) or (getmetatable(skt) == _skt_mt_udp) then

--- a/tests/tls-params.lua
+++ b/tests/tls-params.lua
@@ -1,0 +1,96 @@
+-- test normalization of the 'sslparams' table passed to copas.wrap()/copas.handler()
+--
+-- Covers the fix for https://github.com/lunarmodules/copas/issues/210:
+--  * an empty (or otherwise malformed) sslparams table used to silently
+--    disable TLS -- identical to passing nil -- even though the doc-comment
+--    claimed it enabled TLS "with defaults". No such defaults exist (a
+--    certificate is mandatory), so normalize_sslt() now only recognizes the
+--    current {wrap=..., sni=...} shape by the presence of those two keys;
+--    anything else (an empty table, a garbage-key table, or the legacy flat
+--    luasec-context table) is passed straight through as 'wrap' parameters,
+--    which LuaSec itself validates and errors on when actually used for a
+--    handshake. This never fails open into silent plaintext.
+-- Also checks the other supported shapes still normalize as before: no
+-- params at all, the legacy flat luasec-context table, and the current
+-- {wrap=..., sni=...} table.
+
+local copas = require("copas")
+local socket = require("socket")
+
+local failures = 0
+
+local function check(cond, msg)
+  if cond then
+    print("OK:     "..msg)
+  else
+    print("FAILED: "..msg)
+    failures = failures + 1
+  end
+end
+
+-- no ssl params at all: TLS fully disabled, no error
+do
+  local skt = copas.wrap(socket.tcp())
+  check(skt.ssl_params.wrap == false, "nil sslparams: wrap is false")
+  check(skt.ssl_params.sni == false, "nil sslparams: sni is false")
+end
+
+-- empty table: has neither 'wrap' nor 'sni' keys, so it is treated as a
+-- (malformed) flat luasec-context table rather than silently disabling TLS.
+-- It must never normalize to wrap==false, and using it for a handshake must
+-- error rather than silently proceed unencrypted.
+do
+  local sslt = {}
+  local skt = copas.wrap(socket.tcp(), sslt)
+  check(skt.ssl_params.wrap == sslt, "empty sslparams table: wrap is the table itself, not false")
+  check(skt.ssl_params.sni == false, "empty sslparams table: sni is false")
+
+  local ok, err = pcall(skt.dohandshake, skt)
+  check(not ok, "empty sslparams table: handshake throws instead of silently succeeding")
+  check(tostring(err):match("create") ~= nil,
+    "empty sslparams table: LuaSec's own error surfaces, got: "..tostring(err))
+end
+
+-- table with unrelated/misspelled keys: same as the empty-table case, this
+-- must not be mistaken for the current {wrap=..., sni=...} format either.
+do
+  local sslt = { just_some_key = true }
+  local skt = copas.wrap(socket.tcp(), sslt)
+  check(skt.ssl_params.wrap == sslt, "garbage-key sslparams table: wrap is the table itself, not false")
+  check(skt.ssl_params.sni == false, "garbage-key sslparams table: sni is false")
+
+  local ok, err = pcall(skt.dohandshake, skt)
+  check(not ok, "garbage-key sslparams table: handshake throws instead of silently succeeding")
+  check(tostring(err):match("create") ~= nil,
+    "garbage-key sslparams table: LuaSec's own error surfaces, got: "..tostring(err))
+end
+
+-- legacy flat table (luasec context params directly, no wrap/sni keys)
+do
+  local sslt = {
+    mode = "client",
+    protocol = "any",
+  }
+  local skt = copas.wrap(socket.tcp(), sslt)
+  check(skt.ssl_params.wrap == sslt, "legacy sslparams: wrap is the sslparams table itself")
+  check(skt.ssl_params.sni == false, "legacy sslparams: sni is false")
+end
+
+-- current-style table with both wrap and sni set
+do
+  local sslt = {
+    wrap = { mode = "client", protocol = "any" },
+    sni = { names = "myhost.com", strict = true },
+  }
+  local skt = copas.wrap(socket.tcp(), sslt)
+  check(skt.ssl_params.wrap == sslt.wrap, "current sslparams: wrap matches provided table")
+  check(skt.ssl_params.sni == sslt.sni, "current sslparams: sni matches provided table")
+end
+
+if failures > 0 then
+  print(failures.." check(s) failed")
+  os.exit(1)
+end
+
+print("all checks passed")
+os.exit(0)


### PR DESCRIPTION
normalize_sslt() detected the current {wrap=, sni=} table format by
checking for the legacy 'mode'/'protocol' keys, so any table lacking
those (an empty table, or one with unrelated/misspelled keys) fell
into the "current format" branch and both wrap and sni silently
defaulted to false, identical to passing nil. Since a doc-comment
claimed an empty table meant "TLS with defaults" (no such defaults
exist -- a certificate is mandatory), following that comment produced
a plaintext socket with no error.

Detection is now based on the presence of the 'wrap'/'sni' keys
themselves. Anything without them (empty table, garbage keys, or a
genuine legacy flat luasec-context table) is passed straight through
as 'wrap' parameters, which LuaSec validates and errors on when a
handshake is actually attempted -- so this can no longer fail open
into silent plaintext.

Adds tests/tls-params.lua covering all normalization shapes: no
params, empty/garbage tables, the legacy flat table, and the current
{wrap=, sni=} table.

Fixes https://github.com/lunarmodules/copas/issues/210