### PR TITLE
fix(timer): rearming a timer from its own callback can leak

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -102,6 +102,9 @@ luarocks install copas
 
     <dt><strong>Copas 4.x.x</strong> [unreleased]</dt>
 	<dd><ul>
+        <li>Fix: a recurring timer that cancelled and immediately re-armed itself from within
+        its own callback leaked the old (cancelled) coroutine into the sleeping heap. The old
+        coroutine would sit there for its full delay (#213).</li>
         <li>Fix: TLS <code>sslparams</code> tables that didn't contain the current
         <code>wrap</code>/<code>sni</code> keys (e.g. an empty table, or one with misspelled keys)
         were misidentified and silently ended up disabling TLS, producing a plaintext connection

--- a/src/copas/timer.lua
+++ b/src/copas/timer.lua
@@ -25,11 +25,20 @@ end
 
 do
   local function expire_func(self, initial_delay)
+    local my_co = coroutine_running()
     if self.errorhandler then
       copas.seterrorhandler(self.errorhandler)
     end
     copas.pause(initial_delay)
     while true do
+      if self.co ~= my_co then
+        -- This generation was replaced (eg. the callback cancelled and
+        -- rearmed the timer, synchronously, before returning). `self.co`
+        -- and `self.cancelled` now belong to the new generation, so this
+        -- coroutine must exit without touching them.
+        return
+      end
+
       if not self.cancelled then
         if not self.recurring then
           -- non-recurring timer
@@ -43,6 +52,11 @@ do
           -- recurring timer
           self:callback(self.params)
         end
+      end
+
+      if self.co ~= my_co then
+        -- replaced while the callback was running, see above
+        return
       end
 
       if self.cancelled then

--- a/tests/timer.lua
+++ b/tests/timer.lua
@@ -172,4 +172,65 @@ copas.loop(function()
 end)
 
 assert(successes == 17, "number of successes didn't match! got: "..successes)
+
+-- Regression test for https://github.com/lunarmodules/copas/issues/213
+-- A recurring timer that cancels-and-rearms itself from within its own
+-- callback must not leak the cancelled (old-generation) coroutine into the
+-- sleeping heap. Each leaked coroutine would sit there for its full delay,
+-- consuming a slot until it (eventually) expires -- forever, for a delay of
+-- math.huge, as in the original report.
+-- Run in its own isolated loop so the sleeping-heap count isn't affected by
+-- other tests' timers.
+local leaktest_done = false
+
+copas.loop(function()
+  local rearm_count = 0
+  local max_rearms = 5
+  local baseline = copas.status().timer
+
+  local leak_timer
+  leak_timer = timer.new({
+    delay = 2,  -- long enough that a leaked old-generation coroutine is still parked when checked
+    initial_delay = 0,
+    recurring = true,
+    callback = function(timer_obj)
+      rearm_count = rearm_count + 1
+      if rearm_count <= max_rearms then
+        assert(timer_obj:cancel())
+        assert(timer_obj:arm(0))
+      else
+        assert(timer_obj:cancel())
+      end
+    end,
+  })
+
+  -- watchdog: without the fix, the leaked coroutines keep the loop alive
+  -- until their delay expires (or forever, for math.huge). Bound the
+  -- failure mode instead of letting the test suite hang.
+  local watchdog
+  watchdog = timer.new({
+    delay = 5,
+    callback = function()
+      print("timer leak regression test (issue #213) did not complete within 5 seconds")
+      os.exit(1)
+    end,
+  })
+
+  copas.addthread(function()
+    while rearm_count <= max_rearms do
+      copas.pause(0.01)
+    end
+    copas.pause(0.05) -- let everything settle
+
+    assert(leak_timer.cancelled, "expected the timer to be cancelled")
+    local timer_count = copas.status().timer
+    assert(timer_count <= baseline + 1,
+      "leaked timer coroutines detected: expected around "..baseline..", got "..timer_count)
+
+    watchdog:cancel()
+    leaktest_done = true
+  end)
+end)
+
+assert(leaktest_done, "timer leak regression test (issue #213) did not complete")
 print("test success!")


### PR DESCRIPTION
cancel() and arm() mutated the same shared self.cancelled flag and self.co reference. A recurring timer that called cancel() and then arm() synchronously from within its own callback would have arm() reset self.cancelled to false before the still-running old-generation coroutine got a chance to check it. That coroutine then looped back into copas.pause(self.delay) instead of exiting, leaking a coroutine into the sleeping heap on every such cancel+arm cycle.

Fixes #213