### PR TITLE
fix(http): strip URL fragment before sending request line

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -102,6 +102,10 @@ luarocks install copas
 
     <dt><strong>Copas 4.x.x</strong> [unreleased]</dt>
 	<dd><ul>
+        <li>Fix: <code>copas.http</code> included the URL fragment in the request line sent to
+        the origin server (and, in proxy mode, to the proxy). Fragments are client-side only and
+        must never be transmitted on the wire; a fragment containing sensitive data (e.g. an OAuth
+        callback token) was disclosed to the server and to proxy infrastructure/logs (#220).</li>
         <li>Fix: <code>sock:dohandshake()</code> returned <code>nil + err</code> on a handshake
         timeout instead of throwing like every other failure path. A
         timed-out handshake could leave a connection running without the intended TLS

--- a/src/copas/http.lua
+++ b/src/copas/http.lua
@@ -204,13 +204,13 @@ end
 -----------------------------------------------------------------------------
 local function adjusturi(reqt)
     local u = reqt
+    reqt.fragment = nil -- fragments are client-side only and must never be sent on the wire
     -- if there is a proxy, we need the full url. otherwise, just a part.
     if not reqt.proxy and not _M.PROXY then
         u = {
            path = socket.try(reqt.path, "invalid path 'nil'"),
            params = reqt.params,
            query = reqt.query,
-           fragment = reqt.fragment
         }
     end
     return url.build(u)


### PR DESCRIPTION
Fragments are client-side only and must never be transmitted on the wire, but adjusturi() carried them into the request-target sent to the origin server, and in proxy mode into the full URL sent to the proxy. A fragment holding sensitive data (e.g. an OAuth callback token) was disclosed to the server and to proxy infrastructure/logs.

Fixes https://github.com/lunarmodules/copas/issues/220