### PR TITLE
fix(receive): tcp read '0' is a no-op

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -102,6 +102,10 @@ luarocks install copas
 
     <dt><strong>Copas 4.x.x</strong> [unreleased]</dt>
 	<dd><ul>
+        <li>Fix: a 0-byte <code>receive(0)</code> on a TCP/SSL socket was treated like a normal
+        read and queued the caller on <code>select</code>, blocking until more data arrived even
+        though nothing was needed. Per POSIX, a 0-byte read on a stream socket is a no-op; it now
+        returns <code>""</code> immediately (#223).</li>
         <li>Fix: <code>copas.http</code> included the URL fragment in the request line sent to
         the origin server (and, in proxy mode, to the proxy). Fragments are client-side only and
         must never be transmitted on the wire; a fragment containing sensitive data (e.g. an OAuth

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -542,6 +542,15 @@ local isTCP do
 end
 
 
+-- POSIX: a 0-byte read on a stream socket (TCP/SSL) is a no-op and must
+-- return immediately without waiting on `select`. UDP is different: a
+-- 0-byte datagram is a distinct payload, so it must still wait.
+-- See https://github.com/lunarmodules/copas/issues/223
+local function is_zero_byte_tcp_read(client, pattern)
+  return pattern == 0 and isTCP(client)
+end
+
+
 function copas.close(skt, ...)
   _closed[#_closed+1] = skt
   return skt:close(...)
@@ -609,6 +618,11 @@ end
 -- untrusted/remote input without an application-enforced size limit; use a
 -- numeric (sized) pattern or receivepartial with your own cumulative cap instead.
 function copas.receive(client, pattern, part)
+  if is_zero_byte_tcp_read(client, pattern) then
+    copas.pause() -- yield so a tight receive(0) loop can't starve other coroutines
+    return part or "", nil, nil
+  end
+
   local s, err
   pattern = pattern or "*l"
   local current_log = _reading_log
@@ -704,6 +718,11 @@ end
 -- same as above but with special treatment when reading chunks,
 -- unblocks on any data received.
 function copas.receivepartial(client, pattern, part)
+  if is_zero_byte_tcp_read(client, pattern) then
+    copas.pause() -- yield so a tight receive(0) loop can't starve other coroutines
+    return part or "", nil, nil
+  end
+
   local s, err
   pattern = pattern or "*l"
   local orig_size = #(part or "")

--- a/tests/tcptimeout.lua
+++ b/tests/tcptimeout.lua
@@ -159,6 +159,34 @@ function tests.receive_timeout()
 end
 
 
+-- See issue https://github.com/lunarmodules/copas/issues/223
+-- A 0-byte read on a TCP socket is a POSIX no-op: it must return
+-- immediately without waiting for the socket to become readable, unlike a
+-- normal (>0 byte) read which would sit in the `select` wait set.
+function tests.receive_zero_bytes_returns_immediately()
+  local ip, port = singleuseechoserver()
+
+  copas.addthread(function()
+    local client = socket.tcp()
+    client = copas.wrap(client)
+    -- long enough that hitting it would mean the bug is back
+    client:settimeout(1)
+    local status, err = client:connect(ip, port)
+    assert(status, "failed to connect: "..tostring(err))
+
+    -- nothing is ever sent by the peer, so a normal read would time out
+    local start = copas.gettime()
+    local data, err = client:receive(0)
+    assert(data == "", "expected an immediate empty read, got: "..tostring(data)..", err: "..tostring(err))
+    assert(copas.gettime() - start < 0.5, "receive(0) waited on the socket instead of returning immediately")
+
+    client:close()
+  end)
+
+  copas.loop()
+end
+
+
 function tests.receive_timeout_clears_copas_timeout()
   -- See issue https://github.com/lunarmodules/copas/issues/185
   local server = socket.bind("127.0.0.1", 0)


### PR DESCRIPTION
In Posix a TCP read of 0 bytes shouldn't wait for a socket to become readable, it should instantly return.

Fixes #223 